### PR TITLE
Feature/extract method

### DIFF
--- a/keymaps/php-integrator-refactoring.cson
+++ b/keymaps/php-integrator-refactoring.cson
@@ -1,0 +1,11 @@
+# Keybindings require three things to be fully defined: A selector that is
+# matched against the focused element, the keystroke and the command to
+# execute.
+#
+# Below is a basic keybinding which registers on all platforms by applying to
+# the root workspace element.
+
+# For more detailed documentation see
+# https://atom.io/docs/latest/behind-atom-keymaps-in-depth
+'atom-text-editor':
+  'alt-m': 'php-integrator-refactoring:extract-method'

--- a/lib/AbstractProvider.coffee
+++ b/lib/AbstractProvider.coffee
@@ -15,6 +15,11 @@ class AbstractProvider
     menuItemDisposable: null
 
     ###*
+     * Service to insert snippets into the editor.
+    ###
+    snippetManager: null
+
+    ###*
      * Constructor.
     ###
     constructor: () ->
@@ -118,3 +123,10 @@ class AbstractProvider
      * @param {TextEditor} editor TextEditor to register events to.
     ###
     registerEvents: (editor) ->
+
+    ###*
+     * Sets the snippet manager
+     *
+     * @param {Object} @snippetManager
+    ###
+    setSnippetManager: (@snippetManager) ->

--- a/lib/ExtractMethodProvider.coffee
+++ b/lib/ExtractMethodProvider.coffee
@@ -103,8 +103,6 @@ class ExtractMethodProvider extends AbstractProvider
         )
         activeTextEditor = atom.workspace.getActiveTextEditor()
 
-        activeTextEditor.insertText(methodCall)
-
         highlightedBufferPosition = activeTextEditor.getSelectedBufferRange().end
         row = 0
         loop
@@ -116,20 +114,22 @@ class ExtractMethodProvider extends AbstractProvider
             break if indexOfDescriptor == descriptions.scopes.length - 1 || row == activeTextEditor.getLineCount()
 
         replaceRange = [
-            [highlightedBufferPosition.row + row, activeTextEditor.getTabLength()],
+            [highlightedBufferPosition.row + row, activeTextEditor.getTabLength() + 1],
             [highlightedBufferPosition.row + row, Infinity]
         ]
-        previousText  = activeTextEditor.getTextInBufferRange(replaceRange)
 
         settings.tabs = true
         newMethodBody =  @builder.buildMethod(settings)
 
         @builder.cleanUp()
 
-        activeTextEditor.setTextInBufferRange(
-            replaceRange,
-            "#{previousText}\n\n#{newMethodBody}\n"
-        )
+        activeTextEditor.transact () =>
+            activeTextEditor.insertText(methodCall)
+
+            activeTextEditor.setTextInBufferRange(
+                replaceRange,
+                "\n#{newMethodBody}"
+            )
 
     ###*
      * @inheritdoc

--- a/lib/ExtractMethodProvider.coffee
+++ b/lib/ExtractMethodProvider.coffee
@@ -174,22 +174,37 @@ class ExtractMethodProvider extends AbstractProvider
             # lines and thus offsetting this
             row -= selectedBufferRange.end.row - selectedBufferRange.start.row
 
-            activeTextEditor.setCursorBufferPosition [row + 1, 0]
+            if @snippetManager?
+                activeTextEditor.setCursorBufferPosition [row + 1, 0]
 
-            body = "\n#{newMethodBody}\n"
+                body = "\n#{newMethodBody}\n"
 
-            result = @getTabStopsForBody body
+                result = @getTabStopsForBody body
 
-            snippet = {
-                body: body,
-                lineCount: result.lineCount,
-                tabStops: result.tabStops
-            }
+                snippet = {
+                    body: body,
+                    lineCount: result.lineCount,
+                    tabStops: result.tabStops
+                }
 
-            @snippetManager.insertSnippet(
-                snippet,
-                activeTextEditor
-            )
+                @snippetManager.insertSnippet(
+                    snippet,
+                    activeTextEditor
+                )
+            else
+                # Re working out range as inserting method call will delete some
+                # lines and thus offsetting this
+                row -= selectedBufferRange.end.row - selectedBufferRange.start.row
+
+                replaceRange = [
+                    [row, 0],
+                    [row, line?.length]
+                ]
+
+                activeTextEditor.setTextInBufferRange(
+                    replaceRange,
+                    "#{previousText}\n\n#{newMethodBody}"
+                )
 
     ###*
      * @inheritdoc

--- a/lib/ExtractMethodProvider.coffee
+++ b/lib/ExtractMethodProvider.coffee
@@ -14,9 +14,16 @@ class ExtractMethodProvider extends AbstractProvider
 
     ###*
      * View that the user interacts with when extracting code.
+     *
+     * @type {View}
     ###
     extractMethodView: null
 
+    ###*
+     * Builder used to generate the new method.
+     *
+     * @type {Builder}
+    ###
     builder: null
 
     ###*
@@ -77,6 +84,13 @@ class ExtractMethodProvider extends AbstractProvider
         @extractMethodView.storeFocusedElement()
         @extractMethodView.present()
 
+    ###*
+     * Called when the user has confirmed the extraction in the modal.
+     *
+     * @param  {Object} settings
+     *
+     * @see ParameterParser.buildMethod for structure of settings
+    ###
     onConfirm: (settings) ->
         methodCall = @builder.buildMethodCall(
             settings.methodName

--- a/lib/ExtractMethodProvider.coffee
+++ b/lib/ExtractMethodProvider.coffee
@@ -144,6 +144,7 @@ class ExtractMethodProvider extends AbstractProvider
 
         settings.tabs = true
         newMethodBody =  @builder.buildMethod(settings)
+        settings.tabs = false
 
         @builder.cleanUp()
 

--- a/lib/ExtractMethodProvider.coffee
+++ b/lib/ExtractMethodProvider.coffee
@@ -26,9 +26,8 @@ class ExtractMethodProvider extends AbstractProvider
         super(service)
 
         @extractMethodView = new View(@onConfirm.bind(this))
-        @builder = new Builder()
+        @builder = new Builder(service)
 
-        @builder.setService(service)
         @extractMethodView.setBuilder(@builder)
 
         atom.commands.add 'atom-text-editor', "php-integrator-refactoring:extract-method": =>

--- a/lib/ExtractMethodProvider.coffee
+++ b/lib/ExtractMethodProvider.coffee
@@ -77,9 +77,9 @@ class ExtractMethodProvider extends AbstractProvider
 
         # Replacing double indents with one, so it can be shown in the preview
         # area of panel
-        reducedHighligtedText = highlightedText.replace(findMultipleTab, "#{tabText}")
+        reducedHighlightedText = highlightedText.replace(findMultipleTab, "#{tabText}")
 
-        @builder.setMethodBody(reducedHighligtedText)
+        @builder.setMethodBody(reducedHighlightedText)
         @builder.setEditor(activeTextEditor)
         @extractMethodView.storeFocusedElement()
         @extractMethodView.present()

--- a/lib/ExtractMethodProvider.coffee
+++ b/lib/ExtractMethodProvider.coffee
@@ -147,7 +147,16 @@ class ExtractMethodProvider extends AbstractProvider
         @builder.cleanUp()
 
         activeTextEditor.transact () =>
-            activeTextEditor.insertText(methodCall)
+            extendedRange = @builder.selectedBufferRange
+            activeTextEditor.setSelectedBufferRange extendedRange
+
+            # Matching current indentation
+            selectedText = activeTextEditor.getSelectedText()
+            spacing = selectedText.match /^\s*/
+            if spacing != null
+                spacing = spacing[0]
+
+            activeTextEditor.insertText(spacing + methodCall)
 
             # Remove any extra new lines between functions
             nextLine = activeTextEditor.lineTextForBufferRow row + 1

--- a/lib/ExtractMethodProvider.coffee
+++ b/lib/ExtractMethodProvider.coffee
@@ -32,7 +32,7 @@ class ExtractMethodProvider extends AbstractProvider
     activate: (service) ->
         super(service)
 
-        @extractMethodView = new View(@onConfirm.bind(this))
+        @extractMethodView = new View(@onConfirm.bind(this), @onCancel.bind(this))
         @builder = new Builder(service)
 
         @extractMethodView.setBuilder(@builder)
@@ -83,6 +83,12 @@ class ExtractMethodProvider extends AbstractProvider
         @builder.setEditor(activeTextEditor)
         @extractMethodView.storeFocusedElement()
         @extractMethodView.present()
+
+    ###*
+     * Called when the user has cancel the extraction in the modal.
+    ###
+    onCancel: ->
+        @builder.cleanUp()
 
     ###*
      * Called when the user has confirmed the extraction in the modal.

--- a/lib/ExtractMethodProvider.coffee
+++ b/lib/ExtractMethodProvider.coffee
@@ -61,6 +61,19 @@ class ExtractMethodProvider extends AbstractProvider
         tabText = activeTextEditor.getTabText()
 
         selectedBufferRange = activeTextEditor.getSelectedBufferRange()
+
+        # Checking if a selection has been made
+        if selectedBufferRange.start.row == selectedBufferRange.end.row &&
+        selectedBufferRange.start.column == selectedBufferRange.end.column
+            atom.notifications.addWarning(
+                'You must select some text to extract',
+                {
+                    detail: 'PHP Integrator Refactoring'
+                    dismissable: true
+                }
+            )
+            return
+
         extendedRange = new Range(
             [selectedBufferRange.start.row, 0],
             [selectedBufferRange.end.row, Infinity]

--- a/lib/ExtractMethodProvider.coffee
+++ b/lib/ExtractMethodProvider.coffee
@@ -132,9 +132,11 @@ class ExtractMethodProvider extends AbstractProvider
 
         line = activeTextEditor.lineTextForBufferRow row
 
+        endOfLine = line?.length
+
         replaceRange = [
             [row, 0],
-            [row, line.length]
+            [row, endOfLine]
         ]
 
         previousText = activeTextEditor.getTextInBufferRange replaceRange
@@ -165,7 +167,7 @@ class ExtractMethodProvider extends AbstractProvider
 
             replaceRange = [
                 [row, 0],
-                [row, line.length]
+                [row, line?.length]
             ]
 
             activeTextEditor.setTextInBufferRange(

--- a/lib/ExtractMethodProvider.coffee
+++ b/lib/ExtractMethodProvider.coffee
@@ -105,6 +105,8 @@ class ExtractMethodProvider extends AbstractProvider
         settings.tabs = true
         newMethodBody =  @builder.buildMethod(settings)
 
+        @builder.cleanUp()
+
         activeTextEditor.setTextInBufferRange(
             replaceRange,
             "#{previousText}\n\n#{newMethodBody}\n"

--- a/lib/ExtractMethodProvider.coffee
+++ b/lib/ExtractMethodProvider.coffee
@@ -1,0 +1,111 @@
+{Range} = require 'atom'
+
+AbstractProvider = require './AbstractProvider'
+
+View = require './ExtractMethodProvider/View'
+Builder = require './ExtractMethodProvider/Builder'
+
+module.exports =
+
+##*
+# Provides method extraction capabilities.
+##
+class ExtractMethodProvider extends AbstractProvider
+
+    ###*
+     * View that the user interacts with when extracting code.
+    ###
+    extractMethodView: null
+
+    builder: null
+
+    ###*
+     * @inheritdoc
+    ###
+    activate: (service) ->
+        super(service)
+
+        @extractMethodView = new View(@onConfirm.bind(this))
+        @builder = new Builder()
+
+        @builder.setService(service)
+        @extractMethodView.setBuilder(@builder)
+
+        atom.commands.add 'atom-text-editor', "php-integrator-refactoring:extract-method": =>
+            @executeCommand()
+
+    ###*
+     * @inheritdoc
+    ###
+    deactivate: () ->
+        super()
+
+        if @extractMethodView
+            @extractMethodView.destroy()
+            @extractMethodView = null
+
+    ###*
+     * Executes the extraction.
+    ###
+    executeCommand: () ->
+        activeTextEditor = atom.workspace.getActiveTextEditor()
+
+        return if not activeTextEditor
+
+        tabText = activeTextEditor.getTabText()
+
+        selectedBufferRange = activeTextEditor.getSelectedBufferRange()
+        extendedRange = new Range(
+            [selectedBufferRange.start.row, 0],
+            [selectedBufferRange.end.row, Infinity]
+        )
+        highlightedText = activeTextEditor.getTextInBufferRange(extendedRange)
+
+
+        line = activeTextEditor.lineTextForBufferRow(selectedBufferRange.start.row)
+        findSingleTab = new RegExp("(#{tabText})", "g")
+        matches = (line.match(findSingleTab) || []).length
+
+        multipleTabTexts = Array(matches).fill("#{tabText}")
+        findMultipleTab = new RegExp("^" + multipleTabTexts.join(''), "mg")
+
+        # Replacing double indents with one, so it can be shown in the preview
+        # area of panel
+        reducedHighligtedText = highlightedText.replace(findMultipleTab, "#{tabText}")
+
+        @builder.setMethodBody(reducedHighligtedText)
+        @builder.setEditor(activeTextEditor)
+        @extractMethodView.storeFocusedElement()
+        @extractMethodView.present()
+
+    onConfirm: (settings) ->
+        methodCall = @builder.buildMethodCall(
+            settings.methodName
+        )
+        activeTextEditor = atom.workspace.getActiveTextEditor()
+
+        activeTextEditor.insertText(methodCall)
+
+        highlightedBufferPosition = activeTextEditor.getSelectedBufferRange().end
+        row = 0
+        loop
+            row++
+            descriptions = activeTextEditor.scopeDescriptorForBufferPosition(
+                [highlightedBufferPosition.row + row, activeTextEditor.getTabLength()]
+            )
+            indexOfDescriptor = descriptions.scopes.indexOf('punctuation.section.scope.end.php')
+            break if indexOfDescriptor == descriptions.scopes.length - 1 || row == activeTextEditor.getLineCount()
+
+        replaceRange = [
+            [highlightedBufferPosition.row + row, activeTextEditor.getTabLength()],
+            [highlightedBufferPosition.row + row, Infinity]
+        ]
+        previousText  = activeTextEditor.getTextInBufferRange(replaceRange)
+
+        settings.tabs = true
+        newMethodBody =  @builder.buildMethod(settings)
+
+        activeTextEditor.setTextInBufferRange(
+            replaceRange,
+            "#{previousText}\n\n#{newMethodBody}\n"
+        )

--- a/lib/ExtractMethodProvider.coffee
+++ b/lib/ExtractMethodProvider.coffee
@@ -124,3 +124,11 @@ class ExtractMethodProvider extends AbstractProvider
             replaceRange,
             "#{previousText}\n\n#{newMethodBody}\n"
         )
+
+    ###*
+     * @inheritdoc
+    ###
+    getMenuItems: () ->
+        return [
+            {'label': 'Extract method', 'command': 'php-integrator-refactoring:extract-method'},
+        ]

--- a/lib/ExtractMethodProvider/Builder.coffee
+++ b/lib/ExtractMethodProvider/Builder.coffee
@@ -1,0 +1,183 @@
+{Point, Range} = require 'atom'
+
+module.exports =
+
+class Builder
+
+    methodBody: ''
+
+    tabText: ''
+
+    service: null
+
+    selectedBufferRange: null
+
+    editor: null
+
+    setMethodBody: (text) ->
+        @methodBody = text
+
+    setTabText: (tab) ->
+        @tabText = tab
+
+    setService: (service) ->
+        @service = service
+
+    setSelectedBufferRange: (range) ->
+        @selectedBufferRange = range
+
+    setEditor: (editor) =>
+        @editor = editor
+        @setTabText(editor.getTabText())
+        @setSelectedBufferRange(editor.getSelectedBufferRange())
+
+    buildMethod: (settings) =>
+        parameters = @buildParameters @methodBody
+        newMethod = @buildLine "#{settings.visibility} function #{settings.methodName}(#{parameters.join ', '})", settings.tabs
+        newMethod += @buildLine "{", settings.tabs
+        for line in @methodBody.split('\n')
+            newMethod += @buildLine "#{line}", settings.tabs
+        newMethod += @buildLine "}", settings.tabs
+
+        if settings.generateDocs
+            docs = @buildDocumentation settings.methodName, parameters, settings.tabs
+            newMethod = docs + newMethod
+
+        return newMethod
+
+    buildMethodCall: (methodName, variable) =>
+        parameters = @buildParameters(@methodBody).join(', ')
+        methodCall = "$this->#{methodName}(#{parameters});"
+
+        if variable != undefined
+            methodCall = "$#{variable} = #{methodCall}"
+
+        return methodCall
+
+    buildParameters: (methodBody) ->
+        parameters = []
+
+        @editor.scanInBufferRange /\$[a-zA-Z0-9_]+/g, @selectedBufferRange, (element) =>
+            # Making sure we matched a variable and not a variable within a string
+            descriptions = @editor.scopeDescriptorForBufferPosition(element.range.start)
+            indexOfDescriptor = descriptions.scopes.indexOf('variable.other.php')
+            if indexOfDescriptor > -1
+                parameters.push element.matchText
+
+        regexFilters = [
+            /as\s(\$[a-zA-Z0-9_]+)(?:\s=>\s(\$[a-zA-Z0-9_]+))?/g, # Foreach loops
+            /for\s*\(\s*(\$[a-zA-Z0-9_]+)\s*=/g, # For loops
+            /catch(?:.|\s)+(\$[a-zA-Z0-9_]+)/g, #Try/catch with line breaks
+            /function(?:\s|.)*?((?:\$[a-zA-Z0-9_]+)).*?\)/g, # Closure/Anonymous Function
+            /\s*?(\$[a-zA-Z0-9]+)\s*?=(?!>|=)/g # Variable declarations
+        ]
+
+        for filter in regexFilters
+            @editor.scanInBufferRange filter, @selectedBufferRange, (element) =>
+                variables = element.matchText.match /\$[a-zA-Z0-9]+/g
+                startPoint = new Point(element.range.end.row, 0)
+                scopeRange = @getRangeForCurrentScope @editor, startPoint
+
+                scopeText = @editor.getTextInBufferRange(scopeRange)
+                for variable in variables
+                    variableRegex = new RegExp("\\#{variable}", "g")
+                    variableOccurancesInCurrentScope = (scopeText.match(variableRegex) || []).length
+
+                    while true
+                        indexOfVariable = parameters.indexOf variable
+                        parameters.splice indexOfVariable, 1
+
+                        variableOccurancesInCurrentScope--
+                        break unless variableOccurancesInCurrentScope > 0
+
+
+        parameters = @makeUnique parameters
+
+        # Removing $this from parameters as this doesn't need to be passed in
+        if parameters.indexOf('$this') > -1
+            indexOfThis = parameters.indexOf('$this')
+            parameters.splice indexOfThis, 1
+
+        return parameters
+
+    getRangeForCurrentScope: (editor, bufferPosition) ->
+        startScopePoint = null
+        endScopePoint = null
+
+        # First walk back until we find the start of the current scope.
+        for row in [bufferPosition.row .. 0]
+            line = editor.lineTextForBufferRow(row)
+
+            continue if not line
+
+            lastIndex = line.length - 1
+
+            for i in [lastIndex .. 0]
+                descriptions = @editor.scopeDescriptorForBufferPosition(
+                    [row, i]
+                )
+                indexOfDescriptor = descriptions.scopes.indexOf('punctuation.section.scope.begin.php')
+                if indexOfDescriptor > -1
+                    startScopePoint = new Point(row, 0)
+                    break
+
+            break if startScopePoint?
+
+        # Tracks any extra scopes that might exist inside the scope we are
+        # looking for.
+        childScopes = 0
+
+        # Walk forward until we find the end of the current scope
+        for row in [startScopePoint.row .. editor.getLineCount()]
+            line = editor.lineTextForBufferRow(row)
+
+            continue if not line
+
+            for i in [0 .. line.length - 1]
+                descriptions = @editor.scopeDescriptorForBufferPosition(
+                    [row, i]
+                )
+
+                indexOfDescriptor = descriptions.scopes.indexOf('punctuation.section.scope.begin.php')
+                if indexOfDescriptor > -1
+                    childScopes++
+
+                indexOfDescriptor = descriptions.scopes.indexOf('punctuation.section.scope.end.php')
+                if indexOfDescriptor > -1
+                    if childScopes > 0
+                        childScopes--
+
+                    if childScopes == 0
+                        endScopePoint = new Point(row, i + 1)
+                        break
+
+            break if endScopePoint?
+
+        return new Range(startScopePoint, endScopePoint)
+
+    buildDocumentation: (methodName, parameters, tabs = false) =>
+        docs = @buildLine "/**", tabs
+        docs += @buildDocumentationLine "[#{methodName} description]", tabs
+
+        if parameters.length > 0
+            docs += @buildLine " *", tabs
+
+        for parameter in parameters
+            docs += @buildDocumentationLine "@param [type] #{parameter} [description]", tabs
+
+        docs += @buildLine " */", tabs
+
+        return docs
+
+    buildLine: (content, tabs = false) ->
+        if tabs
+            content = "#{@tabText}#{content}"
+        return content + "\n"
+
+    buildDocumentationLine: (content, tabs = false) ->
+        content = " * #{content}"
+        return @buildLine(content, tabs)
+
+    makeUnique: (array) =>
+        return array.filter (item, pos, self) ->
+            return self.indexOf(item) == pos;

--- a/lib/ExtractMethodProvider/Builder.coffee
+++ b/lib/ExtractMethodProvider/Builder.coffee
@@ -1,4 +1,4 @@
-{Point, Range} = require 'atom'
+ParameterParser = require './ParameterParser'
 
 module.exports =
 
@@ -13,6 +13,11 @@ class Builder
     selectedBufferRange: null
 
     editor: null
+
+    parameterParser: null
+
+    constructor: ->
+        @parameterParser = new ParameterParser
 
     setMethodBody: (text) ->
         @methodBody = text
@@ -32,7 +37,10 @@ class Builder
         @setSelectedBufferRange(editor.getSelectedBufferRange())
 
     buildMethod: (settings) =>
-        parameters = @buildParameters @methodBody
+        parameters = @parameterParser.findParameters(
+            @editor,
+            @selectedBufferRange
+        )
         newMethod = @buildLine "#{settings.visibility} function #{settings.methodName}(#{parameters.join ', '})", settings.tabs
         newMethod += @buildLine "{", settings.tabs
         for line in @methodBody.split('\n')
@@ -46,114 +54,16 @@ class Builder
         return newMethod
 
     buildMethodCall: (methodName, variable) =>
-        parameters = @buildParameters(@methodBody).join(', ')
+        parameters = @parameterParser.findParameters(
+            @editor,
+            @selectedBufferRange
+        ).join(', ')
         methodCall = "$this->#{methodName}(#{parameters});"
 
         if variable != undefined
             methodCall = "$#{variable} = #{methodCall}"
 
         return methodCall
-
-    buildParameters: (methodBody) ->
-        parameters = []
-
-        @editor.scanInBufferRange /\$[a-zA-Z0-9_]+/g, @selectedBufferRange, (element) =>
-            # Making sure we matched a variable and not a variable within a string
-            descriptions = @editor.scopeDescriptorForBufferPosition(element.range.start)
-            indexOfDescriptor = descriptions.scopes.indexOf('variable.other.php')
-            if indexOfDescriptor > -1
-                parameters.push element.matchText
-
-        regexFilters = [
-            /as\s(\$[a-zA-Z0-9_]+)(?:\s=>\s(\$[a-zA-Z0-9_]+))?/g, # Foreach loops
-            /for\s*\(\s*(\$[a-zA-Z0-9_]+)\s*=/g, # For loops
-            /catch(?:.|\s)+(\$[a-zA-Z0-9_]+)/g, #Try/catch with line breaks
-            /function(?:\s|.)*?((?:\$[a-zA-Z0-9_]+)).*?\)/g, # Closure/Anonymous Function
-            /\s*?(\$[a-zA-Z0-9]+)\s*?=(?!>|=)/g # Variable declarations
-        ]
-
-        for filter in regexFilters
-            @editor.scanInBufferRange filter, @selectedBufferRange, (element) =>
-                variables = element.matchText.match /\$[a-zA-Z0-9]+/g
-                startPoint = new Point(element.range.end.row, 0)
-                scopeRange = @getRangeForCurrentScope @editor, startPoint
-
-                scopeText = @editor.getTextInBufferRange(scopeRange)
-                for variable in variables
-                    variableRegex = new RegExp("\\#{variable}", "g")
-                    variableOccurancesInCurrentScope = (scopeText.match(variableRegex) || []).length
-
-                    while true
-                        indexOfVariable = parameters.indexOf variable
-                        parameters.splice indexOfVariable, 1
-
-                        variableOccurancesInCurrentScope--
-                        break unless variableOccurancesInCurrentScope > 0
-
-
-        parameters = @makeUnique parameters
-
-        # Removing $this from parameters as this doesn't need to be passed in
-        if parameters.indexOf('$this') > -1
-            indexOfThis = parameters.indexOf('$this')
-            parameters.splice indexOfThis, 1
-
-        return parameters
-
-    getRangeForCurrentScope: (editor, bufferPosition) ->
-        startScopePoint = null
-        endScopePoint = null
-
-        # First walk back until we find the start of the current scope.
-        for row in [bufferPosition.row .. 0]
-            line = editor.lineTextForBufferRow(row)
-
-            continue if not line
-
-            lastIndex = line.length - 1
-
-            for i in [lastIndex .. 0]
-                descriptions = @editor.scopeDescriptorForBufferPosition(
-                    [row, i]
-                )
-                indexOfDescriptor = descriptions.scopes.indexOf('punctuation.section.scope.begin.php')
-                if indexOfDescriptor > -1
-                    startScopePoint = new Point(row, 0)
-                    break
-
-            break if startScopePoint?
-
-        # Tracks any extra scopes that might exist inside the scope we are
-        # looking for.
-        childScopes = 0
-
-        # Walk forward until we find the end of the current scope
-        for row in [startScopePoint.row .. editor.getLineCount()]
-            line = editor.lineTextForBufferRow(row)
-
-            continue if not line
-
-            for i in [0 .. line.length - 1]
-                descriptions = @editor.scopeDescriptorForBufferPosition(
-                    [row, i]
-                )
-
-                indexOfDescriptor = descriptions.scopes.indexOf('punctuation.section.scope.begin.php')
-                if indexOfDescriptor > -1
-                    childScopes++
-
-                indexOfDescriptor = descriptions.scopes.indexOf('punctuation.section.scope.end.php')
-                if indexOfDescriptor > -1
-                    if childScopes > 0
-                        childScopes--
-
-                    if childScopes == 0
-                        endScopePoint = new Point(row, i + 1)
-                        break
-
-            break if endScopePoint?
-
-        return new Range(startScopePoint, endScopePoint)
 
     buildDocumentation: (methodName, parameters, tabs = false) =>
         docs = @buildLine "/**", tabs
@@ -177,7 +87,3 @@ class Builder
     buildDocumentationLine: (content, tabs = false) ->
         content = " * #{content}"
         return @buildLine(content, tabs)
-
-    makeUnique: (array) =>
-        return array.filter (item, pos, self) ->
-            return self.indexOf(item) == pos;

--- a/lib/ExtractMethodProvider/Builder.coffee
+++ b/lib/ExtractMethodProvider/Builder.coffee
@@ -153,7 +153,7 @@ class Builder
      * @param  {String} methodName
      * @param  {String} variable   [Optional]
      *
-     * @return {[type]}            [description]
+     * @return {String}
     ###
     buildMethodCall: (methodName, variable) =>
         parameters = @parameterParser.findParameters(

--- a/lib/ExtractMethodProvider/Builder.coffee
+++ b/lib/ExtractMethodProvider/Builder.coffee
@@ -146,7 +146,7 @@ class Builder
                 parameters,
                 @returnVariables,
                 settings.tabs,
-                settings.generateDocPlaceholders
+                settings.generateDescPlaceholders
             )
             newMethod = docs + newMethod
 
@@ -195,20 +195,20 @@ class Builder
      * @param  {String}     methodName
      * @param  {Array}      parameters
      * @param  {Array|null} returnVariables
-     * @param  {Boolean}    tabs                    = false
-     * @param  {Boolean}    generateDocPlaceholders = true
+     * @param  {Boolean}    tabs                     = false
+     * @param  {Boolean}    generateDescPlaceholders = true
      *
      * @return {String}
     ###
-    buildDocumentation: (methodName, parameters, returnVariables, tabs = false, generateDocPlaceholders = true) =>
+    buildDocumentation: (methodName, parameters, returnVariables, tabs = false, generateDescPlaceholders = true) =>
         docs = @buildLine "/**", tabs
 
-        if generateDocPlaceholders
+        if generateDescPlaceholders
             docs += @buildDocumentationLine "[#{methodName} description]", tabs
 
         if parameters.length > 0
             descriptionPlaceholder = ""
-            if generateDocPlaceholders
+            if generateDescPlaceholders
                 docs += @buildLine " *", tabs
                 descriptionPlaceholder = " [description]"
             longestType = 0

--- a/lib/ExtractMethodProvider/Builder.coffee
+++ b/lib/ExtractMethodProvider/Builder.coffee
@@ -87,3 +87,6 @@ class Builder
     buildDocumentationLine: (content, tabs = false) ->
         content = " * #{content}"
         return @buildLine(content, tabs)
+
+    cleanUp: ->
+        @parameterParser.removeCachedParameters(@editor, @selectedBufferRange)

--- a/lib/ExtractMethodProvider/Builder.coffee
+++ b/lib/ExtractMethodProvider/Builder.coffee
@@ -116,6 +116,7 @@ class Builder
      *   - tabs (boolean)
      *   - generateDocs (boolean)
      *   - arraySyntax (string) ['word', 'brackets']
+     *   - generateDocPlaceholders (boolean)
      *
      * @param  {Object} settings
      *
@@ -140,7 +141,13 @@ class Builder
         newMethod += @buildLine "}", settings.tabs
 
         if settings.generateDocs
-            docs = @buildDocumentation settings.methodName, parameters, @returnVariables, settings.tabs
+            docs = @buildDocumentation(
+                settings.methodName,
+                parameters,
+                @returnVariables,
+                settings.tabs,
+                settings.generateDocPlaceholders
+            )
             newMethod = docs + newMethod
 
         return newMethod
@@ -188,16 +195,22 @@ class Builder
      * @param  {String}     methodName
      * @param  {Array}      parameters
      * @param  {Array|null} returnVariables
-     * @param  {Boolean}    tabs            = false
+     * @param  {Boolean}    tabs                    = false
+     * @param  {Boolean}    generateDocPlaceholders = true
      *
      * @return {String}
     ###
-    buildDocumentation: (methodName, parameters, returnVariables, tabs = false) =>
+    buildDocumentation: (methodName, parameters, returnVariables, tabs = false, generateDocPlaceholders = true) =>
         docs = @buildLine "/**", tabs
-        docs += @buildDocumentationLine "[#{methodName} description]", tabs
+
+        if generateDocPlaceholders
+            docs += @buildDocumentationLine "[#{methodName} description]", tabs
 
         if parameters.length > 0
-            docs += @buildLine " *", tabs
+            descriptionPlaceholder = ""
+            if generateDocPlaceholders
+                docs += @buildLine " *", tabs
+                descriptionPlaceholder = " [description]"
             longestType = 0
             longestVariable = 0
 
@@ -214,7 +227,7 @@ class Builder
                 type = parameter.type + new Array(typePadding + 1).join(' ')
                 variable = parameter.name + new Array(variablePadding + 1).join(' ')
 
-                docs += @buildDocumentationLine "@param #{type} #{variable} [description]", tabs
+                docs += @buildDocumentationLine "@param #{type} #{variable}#{descriptionPlaceholder}", tabs
 
         if returnVariables != null && returnVariables.length > 0
             docs += @buildLine " *", tabs

--- a/lib/ExtractMethodProvider/Builder.coffee
+++ b/lib/ExtractMethodProvider/Builder.coffee
@@ -141,7 +141,7 @@ class Builder
         newMethod += @buildLine "}", settings.tabs
 
         if settings.generateDocs
-            docs = @buildDocumentation settings.methodName, parameters, settings.tabs
+            docs = @buildDocumentation settings.methodName, parameters, @returnVariables, settings.tabs
             newMethod = docs + newMethod
 
         return newMethod
@@ -186,13 +186,14 @@ class Builder
     ###*
      * Builds the docblock for the given method and parameters.
      *
-     * @param  {String}  methodName
-     * @param  {Array}   parameters
-     * @param  {Boolean} tabs       = false
+     * @param  {String}     methodName
+     * @param  {Array}      parameters
+     * @param  {Array|null} returnVariables
+     * @param  {Boolean}    tabs            = false
      *
      * @return {String}
     ###
-    buildDocumentation: (methodName, parameters, tabs = false) =>
+    buildDocumentation: (methodName, parameters, returnVariables, tabs = false) =>
         docs = @buildLine "/**", tabs
         docs += @buildDocumentationLine "[#{methodName} description]", tabs
 
@@ -201,6 +202,14 @@ class Builder
 
         for parameter in parameters
             docs += @buildDocumentationLine "@param #{parameter.type} #{parameter.name} [description]", tabs
+
+        if returnVariables != null && returnVariables.length > 0
+            docs += @buildLine " *", tabs
+
+            if returnVariables.length == 1
+                docs += @buildDocumentationLine "@return #{returnVariables[0].type}", tabs
+            else if returnVariables.length > 1
+                docs += @buildDocumentationLine "@return array", tabs
 
         docs += @buildLine " */", tabs
 

--- a/lib/ExtractMethodProvider/Builder.coffee
+++ b/lib/ExtractMethodProvider/Builder.coffee
@@ -199,9 +199,23 @@ class Builder
 
         if parameters.length > 0
             docs += @buildLine " *", tabs
+            longestType = 0
+            longestVariable = 0
 
-        for parameter in parameters
-            docs += @buildDocumentationLine "@param #{parameter.type} #{parameter.name} [description]", tabs
+            for parameter in parameters
+                if parameter.type.length > longestType
+                    longestType = parameter.type.length
+                if parameter.name.length > longestVariable
+                    longestVariable = parameter.name.length
+
+            for parameter in parameters
+                typePadding = longestType - parameter.type.length
+                variablePadding = longestVariable - parameter.name.length
+
+                type = parameter.type + new Array(typePadding + 1).join(' ')
+                variable = parameter.name + new Array(variablePadding + 1).join(' ')
+
+                docs += @buildDocumentationLine "@param #{type} #{variable} [description]", tabs
 
         if returnVariables != null && returnVariables.length > 0
             docs += @buildLine " *", tabs

--- a/lib/ExtractMethodProvider/Builder.coffee
+++ b/lib/ExtractMethodProvider/Builder.coffee
@@ -256,10 +256,11 @@ class Builder
      *
      * @param  {Array}   variableDeclarations
      * @param  {Boolean} tabs
+     * @param  {String}  arrayType ['word', 'brackets']
      *
      * @return {String}
     ###
-    buildReturnLine: (variableDeclarations, tabs) ->
+    buildReturnLine: (variableDeclarations, tabs, arrayType = 'word') ->
         content = @buildLine '', false
         if variableDeclarations.length == 1
             content += @buildLine "#{@tabText}return #{variableDeclarations[0].name};", tabs
@@ -272,7 +273,12 @@ class Builder
 
                 return previous + ', ' + current.name
 
-            content += @buildLine "#{@tabText}return [#{variables}];", tabs
+            if arrayType == 'brackets'
+                variables = "[#{variables}]"
+            else
+                variables = "array(#{variables})"
+
+            content += @buildLine "#{@tabText}return #{variables};", tabs
             return content
 
         return ''

--- a/lib/ExtractMethodProvider/Builder.coffee
+++ b/lib/ExtractMethodProvider/Builder.coffee
@@ -351,6 +351,9 @@ class Builder
      * @return {String}
     ###
     buildFunctionParameters: (parameters, typeHinting) ->
+        if parameters.length == 0
+            return ''
+
         if parameters.length == 1
             return @convertParameterObjectIntoString parameters[0], typeHinting
 

--- a/lib/ExtractMethodProvider/Builder.coffee
+++ b/lib/ExtractMethodProvider/Builder.coffee
@@ -16,8 +16,9 @@ class Builder
 
     parameterParser: null
 
-    constructor: ->
-        @parameterParser = new ParameterParser
+    constructor: (service) ->
+        @setService service
+        @parameterParser = new ParameterParser @service.parser
 
     setMethodBody: (text) ->
         @methodBody = text
@@ -41,7 +42,11 @@ class Builder
             @editor,
             @selectedBufferRange
         )
-        newMethod = @buildLine "#{settings.visibility} function #{settings.methodName}(#{parameters.join ', '})", settings.tabs
+
+        parameterNames = parameters.map (item) ->
+            return item.name
+
+        newMethod = @buildLine "#{settings.visibility} function #{settings.methodName}(#{parameterNames.join ', '})", settings.tabs
         newMethod += @buildLine "{", settings.tabs
         for line in @methodBody.split('\n')
             newMethod += @buildLine "#{line}", settings.tabs
@@ -57,8 +62,12 @@ class Builder
         parameters = @parameterParser.findParameters(
             @editor,
             @selectedBufferRange
-        ).join(', ')
-        methodCall = "$this->#{methodName}(#{parameters});"
+        )
+
+        parameterNames = parameters.map (item) ->
+            return item.name
+
+        methodCall = "$this->#{methodName}(#{parameterNames.join ', '});"
 
         if variable != undefined
             methodCall = "$#{variable} = #{methodCall}"
@@ -73,7 +82,7 @@ class Builder
             docs += @buildLine " *", tabs
 
         for parameter in parameters
-            docs += @buildDocumentationLine "@param [type] #{parameter} [description]", tabs
+            docs += @buildDocumentationLine "@param #{parameter.type} #{parameter.name} [description]", tabs
 
         docs += @buildLine " */", tabs
 

--- a/lib/ExtractMethodProvider/Builder.coffee
+++ b/lib/ExtractMethodProvider/Builder.coffee
@@ -115,6 +115,7 @@ class Builder
      *   - visibility (string) ['private', 'protected', 'public']
      *   - tabs (boolean)
      *   - generateDocs (boolean)
+     *   - arraySyntax (string) ['word', 'brackets']
      *
      * @param  {Object} settings
      *
@@ -136,7 +137,7 @@ class Builder
         newMethod += @buildLine "{", settings.tabs
         for line in @methodBody.split('\n')
             newMethod += @buildLine "#{line}", settings.tabs
-        newMethod += @buildReturnLine @returnVariables, settings.tabs
+        newMethod += @buildReturnLine @returnVariables, settings.tabs, settings.arraySyntax
         newMethod += @buildLine "}", settings.tabs
 
         if settings.generateDocs
@@ -301,3 +302,19 @@ class Builder
             return content
 
         return ''
+
+    ###*
+     * Checks if the new method will be returning any values.
+     *
+     * @return {Boolean}
+    ###
+    hasReturnValues: ->
+        return @returnVariables != null && @returnVariables.length > 0
+
+    ###*
+     * Returns if there are multiple return values.
+     *
+     * @return {Boolean}
+    ###
+    hasMultipleReturnValues: ->
+        return @returnVariables != null && @returnVariables.length > 1

--- a/lib/ExtractMethodProvider/Builder.coffee
+++ b/lib/ExtractMethodProvider/Builder.coffee
@@ -167,6 +167,18 @@ class Builder
 
         if variable != undefined
             methodCall = "$#{variable} = #{methodCall}"
+        else
+            if @returnVariables != null
+                if @returnVariables.length == 1
+                    methodCall = "#{@returnVariables[0].name} = #{methodCall}"
+                else if @returnVariables.length > 1
+                    variables = @returnVariables.reduce (previous, current) ->
+                        if typeof previous != 'string'
+                            previous = previous.name
+
+                        return previous + ', ' + current.name
+
+                    methodCall = "list(#{variables}) = #{methodCall}"
 
         return methodCall
 

--- a/lib/ExtractMethodProvider/Builder.coffee
+++ b/lib/ExtractMethodProvider/Builder.coffee
@@ -95,7 +95,7 @@ class Builder
      * @param {Range} range [description]
     ###
     setSelectedBufferRange: (range) ->
-        @selectedBufferRange = range
+        @selectedBufferRange = new Range([range.start.row, 0], [range.end.row, Infinity])
 
     ###*
      * Set the TextEditor to be used when analysing the selectedBufferRange

--- a/lib/ExtractMethodProvider/Builder.coffee
+++ b/lib/ExtractMethodProvider/Builder.coffee
@@ -130,10 +130,10 @@ class Builder
         if @returnVariables == null
             @returnVariables = @workOutReturnVariables @parameterParser.getVariableDeclarations()
 
-        parameterNames = parameters.map (item) ->
-            return item.name
+        formattedParameters = @buildFunctionParameters parameters, settings.typeHinting
+        console.log formattedParameters
 
-        newMethod = @buildLine "#{settings.visibility} function #{settings.methodName}(#{parameterNames.join ', '})", settings.tabs
+        newMethod = @buildLine "#{settings.visibility} function #{settings.methodName}(#{formattedParameters})", settings.tabs
         newMethod += @buildLine "{", settings.tabs
         for line in @methodBody.split('\n')
             newMethod += @buildLine "#{line}", settings.tabs
@@ -341,3 +341,41 @@ class Builder
     ###
     hasMultipleReturnValues: ->
         return @returnVariables != null && @returnVariables.length > 1
+
+    ###*
+     * Builds the parameters inside the () of the function.
+     *
+     * @param  {Array} parameters
+     * @param  {Boolean} typeHinting
+     *
+     * @return {String}
+    ###
+    buildFunctionParameters: (parameters, typeHinting) ->
+        if parameters.length == 1
+            return @convertParameterObjectIntoString parameters[0], typeHinting
+
+        formattedParameters = parameters.reduce (previous, current) =>
+            if typeof previous != 'string'
+                previous = @convertParameterObjectIntoString previous, typeHinting
+
+            current = @convertParameterObjectIntoString current, typeHinting
+
+            return previous + ', ' + current
+
+        return formattedParameters
+
+    ###*
+     * Converts a parameter object into a string to be used in a function
+     *
+     * @param  {Object} parameter
+     * @param  {Boolean} typeHinting
+     *
+     * @return {String}
+    ###
+    convertParameterObjectIntoString: (parameter, typeHinting) ->
+        parameterString = parameter.name
+
+        if typeHinting
+            parameterString = parameter.type + ' ' + parameterString
+
+        return parameterString

--- a/lib/ExtractMethodProvider/Builder.coffee
+++ b/lib/ExtractMethodProvider/Builder.coffee
@@ -225,6 +225,8 @@ class Builder
     ###
     cleanUp: ->
         @parameterParser.removeCachedParameters(@editor, @selectedBufferRange)
+        @returnVariables = null
+        @parameterParser.cleanUp()
 
     ###*
      * Works out which variables need to be returned from the new method.

--- a/lib/ExtractMethodProvider/Builder.coffee
+++ b/lib/ExtractMethodProvider/Builder.coffee
@@ -131,7 +131,6 @@ class Builder
             @returnVariables = @workOutReturnVariables @parameterParser.getVariableDeclarations()
 
         formattedParameters = @buildFunctionParameters parameters, settings.typeHinting
-        console.log formattedParameters
 
         newMethod = @buildLine "#{settings.visibility} function #{settings.methodName}(#{formattedParameters})", settings.tabs
         newMethod += @buildLine "{", settings.tabs

--- a/lib/ExtractMethodProvider/Builder.coffee
+++ b/lib/ExtractMethodProvider/Builder.coffee
@@ -4,39 +4,113 @@ module.exports =
 
 class Builder
 
+    ###*
+     * The body of the new method that will be shown in the preview area.
+     *
+     * @type {String}
+    ###
     methodBody: ''
 
+    ###*
+     * The tab string that is used by the current editor.
+     *
+     * @type {String}
+    ###
     tabText: ''
 
+    ###*
+     * The php-integrator-base service.
+     *
+     * @type {Service}
+    ###
     service: null
 
+    ###*
+     * A range of the selected/highlighted area of code to analyse.
+     *
+     * @type {Range}
+    ###
     selectedBufferRange: null
 
+    ###*
+     * The text editor to be analysing.
+     *
+     * @type {TextEditor}
+    ###
     editor: null
 
+    ###*
+     * The parameter parser that will work out the parameters the
+     * selectedBufferRange will need.
+     *
+     * @type {ParameterParser}
+    ###
     parameterParser: null
 
+    ###*
+     * Constructor.
+     *
+     * @param  {Service} service php-integrator-base service
+    ###
     constructor: (service) ->
         @setService service
         @parameterParser = new ParameterParser @service.parser
 
+    ###*
+     * Sets the method body to use in the preview.
+     *
+     * @param {String} text
+    ###
     setMethodBody: (text) ->
         @methodBody = text
 
+    ###*
+     * The tab string to use when genereating new method.
+     *
+     * @param {String} tab
+    ###
     setTabText: (tab) ->
         @tabText = tab
 
+    ###*
+     * Set the php-integrator-base service to be used.
+     *
+     * @param {Service} service
+    ###
     setService: (service) ->
         @service = service
 
+    ###*
+     * Set the selectedBufferRange to analyse.
+     *
+     * @param {Range} range [description]
+    ###
     setSelectedBufferRange: (range) ->
         @selectedBufferRange = range
 
+    ###*
+     * Set the TextEditor to be used when analysing the selectedBufferRange
+     *
+     * @param {TextEditor} editor [description]
+    ###
     setEditor: (editor) =>
         @editor = editor
         @setTabText(editor.getTabText())
         @setSelectedBufferRange(editor.getSelectedBufferRange())
 
+    ###*
+     * Builds the new method from the selectedBufferRange and settings given.
+     *
+     * The settings parameter should be an object with these properties:
+     *   - methodName (string)
+     *   - visibility (string) ['private', 'protected', 'public']
+     *   - tabs (boolean)
+     *   - generateDocs (boolean)
+     *
+     * @param  {Object} settings
+     *
+     * @return {String}
+    ###
     buildMethod: (settings) =>
         parameters = @parameterParser.findParameters(
             @editor,
@@ -58,6 +132,15 @@ class Builder
 
         return newMethod
 
+    ###*
+     * Build the line that calls the new method and the variable the method
+     * to be assigned to.
+     *
+     * @param  {String} methodName
+     * @param  {String} variable   [Optional]
+     *
+     * @return {[type]}            [description]
+    ###
     buildMethodCall: (methodName, variable) =>
         parameters = @parameterParser.findParameters(
             @editor,
@@ -74,6 +157,15 @@ class Builder
 
         return methodCall
 
+    ###*
+     * Builds the docblock for the given method and parameters.
+     *
+     * @param  {String}  methodName
+     * @param  {Array}   parameters
+     * @param  {Boolean} tabs       = false
+     *
+     * @return {String}
+    ###
     buildDocumentation: (methodName, parameters, tabs = false) =>
         docs = @buildLine "/**", tabs
         docs += @buildDocumentationLine "[#{methodName} description]", tabs
@@ -88,14 +180,35 @@ class Builder
 
         return docs
 
+    ###*
+     * Builds a single line of the new method. This will add a new line to the
+     * end and add any tabs that are needed (if requested).
+     *
+     * @param  {String}  content
+     * @param  {Boolean} tabs    = false
+     *
+     * @return {String}
+    ###
     buildLine: (content, tabs = false) ->
         if tabs
             content = "#{@tabText}#{content}"
         return content + "\n"
 
+    ###*
+     * Builds a documentation line. This uses buildLine function just with
+     * " * " prefixed to the content.
+     *
+     * @param  {String}  content
+     * @param  {Boolean} tabs    = false
+     *
+     * @return {String}
+    ###
     buildDocumentationLine: (content, tabs = false) ->
         content = " * #{content}"
         return @buildLine(content, tabs)
 
+    ###*
+     * Performs any clean up needed with the builder.
+    ###
     cleanUp: ->
         @parameterParser.removeCachedParameters(@editor, @selectedBufferRange)

--- a/lib/ExtractMethodProvider/Builder.coffee
+++ b/lib/ExtractMethodProvider/Builder.coffee
@@ -95,7 +95,7 @@ class Builder
      * @param {Range} range [description]
     ###
     setSelectedBufferRange: (range) ->
-        @selectedBufferRange = new Range([range.start.row, 0], [range.end.row, Infinity])
+        @selectedBufferRange = range
 
     ###*
      * Set the TextEditor to be used when analysing the selectedBufferRange

--- a/lib/ExtractMethodProvider/Builder.coffee
+++ b/lib/ExtractMethodProvider/Builder.coffee
@@ -256,6 +256,8 @@ class Builder
         textAfterExtraction = @editor.getTextInBufferRange lookupRange
         allVariablesAfterExtraction = textAfterExtraction.match /\$[a-zA-Z0-9]+/g
 
+        return null if allVariablesAfterExtraction == null
+
         variableDeclarations = variableDeclarations.filter (variable) =>
             for variables in allVariablesAfterExtraction
                 if variables == variable.name
@@ -275,6 +277,9 @@ class Builder
      * @return {String}
     ###
     buildReturnLine: (variableDeclarations, tabs, arrayType = 'word') ->
+        if variableDeclarations == null
+            return ''
+
         content = @buildLine '', false
         if variableDeclarations.length == 1
             content += @buildLine "#{@tabText}return #{variableDeclarations[0].name};", tabs

--- a/lib/ExtractMethodProvider/ParameterParser.coffee
+++ b/lib/ExtractMethodProvider/ParameterParser.coffee
@@ -86,7 +86,7 @@ class ParameterParser
         variableDeclarations = []
 
         for filter in regexFilters
-            editor.scanInBufferRange filter.regex, selectedBufferRange, (element) =>
+            editor.backwardsScanInBufferRange filter.regex, selectedBufferRange, (element) =>
                 variables = element.matchText.match /\$[a-zA-Z0-9]+/g
                 startPoint = new Point(element.range.end.row, 0)
                 scopeRange = @getRangeForCurrentScope editor, startPoint
@@ -119,7 +119,7 @@ class ParameterParser
 
                         return true
 
-        @variableDeclarations = variableDeclarations
+        @variableDeclarations = @makeUnique variableDeclarations
 
         parameters = @makeUnique parameters
 

--- a/lib/ExtractMethodProvider/ParameterParser.coffee
+++ b/lib/ExtractMethodProvider/ParameterParser.coffee
@@ -71,7 +71,7 @@ class ParameterParser
             },
             {
                 name: 'Try catch',
-                regex: /catch(?:\(|\s)+(\$[a-zA-Z0-9_]+)/g
+                regex: /catch(?:\(|\s)+.*?(\$[a-zA-Z0-9_]+)/g
             },
             {
                 name: 'Closure'

--- a/lib/ExtractMethodProvider/ParameterParser.coffee
+++ b/lib/ExtractMethodProvider/ParameterParser.coffee
@@ -119,3 +119,7 @@ class ParameterParser
 
     buildKey: (editor, selectedBufferRange) ->
         return editor.getPath() + JSON.stringify(selectedBufferRange)
+
+    removeCachedParameters: (editor, selectedBufferRange) ->
+        key = @buildKey(editor, selectedBufferRange)
+        delete @parsedParameters[key]

--- a/lib/ExtractMethodProvider/ParameterParser.coffee
+++ b/lib/ExtractMethodProvider/ParameterParser.coffee
@@ -79,7 +79,7 @@ class ParameterParser
             },
             {
                 name: 'Variable declarations',
-                regex: /\s*?(\$[a-zA-Z0-9]+)\s*?=(?!>|=)/g
+                regex: /(\$[a-zA-Z0-9]+)\s*?=(?!>|=)/g
             }
         ]
 
@@ -106,11 +106,13 @@ class ParameterParser
                     parameters = parameters.filter (parameter) =>
                         if parameter.name != variable
                             return true
-
                         if scopeRange.containsRange(parameter.range)
                             # If variable declaration is after parameter then it's
                             # still needed in parameters.
                             if element.range.start.row > parameter.range.start.row
+                                return true
+                            if element.range.start.row == parameter.range.start.row &&
+                            element.range.start.column > parameter.range.start.column
                                 return true
 
                             return false

--- a/lib/ExtractMethodProvider/ParameterParser.coffee
+++ b/lib/ExtractMethodProvider/ParameterParser.coffee
@@ -4,13 +4,38 @@ module.exports =
 
 class ParameterParser
 
+    ###*
+     * Cached parameters that have already been parsed
+     *
+     * @type {Array}
+    ###
     parsedParameters: []
 
+    ###*
+     * Parser object from the php-integrator-base service
+     *
+     * @type {Parser}
+    ###
     parser: null
 
+    ###*
+     * Constructor
+     *
+     * @param {Parser} parser
+    ###
     constructor: (parser) ->
         @parser = parser
 
+    ###*
+     * Takes the editor and the range and loops through finding all the
+     * parameters that will be needed if this code was to be moved into
+     * its own function
+     *
+     * @param  {TextEditor} editor
+     * @param  {Range}      selectedBufferRange
+     *
+     * @return {Array}
+    ###
     findParameters: (editor, selectedBufferRange) ->
         key = @buildKey(editor, selectedBufferRange)
 
@@ -58,6 +83,7 @@ class ParameterParser
         parameters = parameters.filter (item) ->
             return item.name != '$this'
 
+        # Grab the variable types of the parameters
         parameters = parameters.map (parameter) =>
             try
                 type = @parser.getVariableType(
@@ -82,6 +108,17 @@ class ParameterParser
 
         return parameters
 
+    ###*
+     * Takes the current buffer position and returns a range of the current
+     * scope that the buffer position is in.
+     *
+     * For example this could be the code within an if statement or closure.
+     *
+     * @param  {TextEditor} editor
+     * @param  {Point}      bufferPosition
+     *
+     * @return {Range}
+    ###
     getRangeForCurrentScope: (editor, bufferPosition) ->
         startScopePoint = null
         endScopePoint = null
@@ -137,16 +174,37 @@ class ParameterParser
 
         return new Range(startScopePoint, endScopePoint)
 
+    ###*
+     * Takes an array of parameters and removes any parameters that appear more
+     * that once with the same name.
+     *
+     * @param  {Array} array
+     *
+     * @return {Array}
+    ###
     makeUnique: (array) ->
         return array.filter (filterItem, pos, self) ->
             for i in [0 .. self.length - 1]
                 return self[i].name == filterItem.name &&
                     pos == i
 
-
+    ###*
+     * Generates the key used to store the parameters in the cache.
+     *
+     * @param  {TextEditor} editor
+     * @param  {Range}      selectedBufferRange
+     *
+     * @return {string}
+    ###
     buildKey: (editor, selectedBufferRange) ->
         return editor.getPath() + JSON.stringify(selectedBufferRange)
 
+    ###*
+     * Removes cached parameters by the editor and range given.
+     *
+     * @param  {TextEditor} editor
+     * @param  {Range} selectedBufferRange
+    ###
     removeCachedParameters: (editor, selectedBufferRange) ->
         key = @buildKey(editor, selectedBufferRange)
         delete @parsedParameters[key]

--- a/lib/ExtractMethodProvider/ParameterParser.coffee
+++ b/lib/ExtractMethodProvider/ParameterParser.coffee
@@ -4,7 +4,13 @@ module.exports =
 
 class ParameterParser
 
+    parsedParameters: []
+
     findParameters: (editor, selectedBufferRange) ->
+        key = @buildKey(editor, selectedBufferRange)
+
+        return @parsedParameters[key] if @parsedParameters[key]
+
         parameters = []
 
         editor.scanInBufferRange /\$[a-zA-Z0-9_]+/g, selectedBufferRange, (element) =>
@@ -47,6 +53,8 @@ class ParameterParser
         if parameters.indexOf('$this') > -1
             indexOfThis = parameters.indexOf('$this')
             parameters.splice indexOfThis, 1
+
+        @parsedParameters[key] = parameters
 
         return parameters
 
@@ -105,6 +113,9 @@ class ParameterParser
 
         return new Range(startScopePoint, endScopePoint)
 
-    makeUnique: (array) =>
+    makeUnique: (array) ->
         return array.filter (item, pos, self) ->
             return self.indexOf(item) == pos;
+
+    buildKey: (editor, selectedBufferRange) ->
+        return editor.getPath() + JSON.stringify(selectedBufferRange)

--- a/lib/ExtractMethodProvider/ParameterParser.coffee
+++ b/lib/ExtractMethodProvider/ParameterParser.coffee
@@ -71,7 +71,7 @@ class ParameterParser
             },
             {
                 name: 'Try catch',
-                regex: /catch(?:.|\s)+(\$[a-zA-Z0-9_]+)/g
+                regex: /catch(?:\(|\s)+(\$[a-zA-Z0-9_]+)/g
             },
             {
                 name: 'Closure'

--- a/lib/ExtractMethodProvider/ParameterParser.coffee
+++ b/lib/ExtractMethodProvider/ParameterParser.coffee
@@ -269,7 +269,7 @@ class ParameterParser
         try
             type = @parser.getVariableType(
                 editor,
-                parameter.range.start,
+                new Point(parameter.range.end.row + 1, parameter.range.end.column),
                 parameter.name
             )
         catch error

--- a/lib/ExtractMethodProvider/ParameterParser.coffee
+++ b/lib/ExtractMethodProvider/ParameterParser.coffee
@@ -83,6 +83,8 @@ class ParameterParser
             }
         ]
 
+        variableDeclarations = []
+
         for filter in regexFilters
             editor.scanInBufferRange filter.regex, selectedBufferRange, (element) =>
                 variables = element.matchText.match /\$[a-zA-Z0-9]+/g
@@ -96,8 +98,8 @@ class ParameterParser
                             chosenParameter = parameter
                             break
 
-                    parameter = @getTypeForParameter editor, parameter
-                    @variableDeclarations.push parameter
+                    chosenParameter = @getTypeForParameter editor, chosenParameter
+                    variableDeclarations.push chosenParameter
 
                 for variable in variables
                     parameters = parameters.filter (parameter) =>
@@ -108,6 +110,8 @@ class ParameterParser
                             return false
 
                         return true
+
+        @variableDeclarations = variableDeclarations
 
         parameters = @makeUnique parameters
 
@@ -261,3 +265,9 @@ class ParameterParser
     ###
     getVariableDeclarations: ->
         return @variableDeclarations
+
+    ###*
+     * Clean up any data from previous usage
+    ###
+    cleanUp: ->
+        @variableDeclarations = []

--- a/lib/ExtractMethodProvider/ParameterParser.coffee
+++ b/lib/ExtractMethodProvider/ParameterParser.coffee
@@ -75,7 +75,7 @@ class ParameterParser
             },
             {
                 name: 'Closure'
-                regex: /function(?:\s|.)*?((?:\$[a-zA-Z0-9_]+)).*?\)/g
+                regex: /function(?:\s)*?\((?:\$).*?\)/g
             },
             {
                 name: 'Variable declarations',

--- a/lib/ExtractMethodProvider/ParameterParser.coffee
+++ b/lib/ExtractMethodProvider/ParameterParser.coffee
@@ -194,7 +194,7 @@ class ParameterParser
      * @param  {TextEditor} editor
      * @param  {Range}      selectedBufferRange
      *
-     * @return {string}
+     * @return {String}
     ###
     buildKey: (editor, selectedBufferRange) ->
         return editor.getPath() + JSON.stringify(selectedBufferRange)

--- a/lib/ExtractMethodProvider/ParameterParser.coffee
+++ b/lib/ExtractMethodProvider/ParameterParser.coffee
@@ -98,8 +98,9 @@ class ParameterParser
                             chosenParameter = parameter
                             break
 
-                    chosenParameter = @getTypeForParameter editor, chosenParameter
-                    variableDeclarations.push chosenParameter
+                    if chosenParameter != null
+                        chosenParameter = @getTypeForParameter editor, chosenParameter
+                        variableDeclarations.push chosenParameter
 
                 for variable in variables
                     parameters = parameters.filter (parameter) =>

--- a/lib/ExtractMethodProvider/ParameterParser.coffee
+++ b/lib/ExtractMethodProvider/ParameterParser.coffee
@@ -180,6 +180,9 @@ class ParameterParser
 
             break if startScopePoint?
 
+        if startScopePoint == null
+            startScopePoint = new Point(0, 0)
+
         childScopes = 0
 
         # Walk forward until we find the end of the current scope

--- a/lib/ExtractMethodProvider/ParameterParser.coffee
+++ b/lib/ExtractMethodProvider/ParameterParser.coffee
@@ -201,8 +201,10 @@ class ParameterParser
     makeUnique: (array) ->
         return array.filter (filterItem, pos, self) ->
             for i in [0 .. self.length - 1]
-                return self[i].name == filterItem.name &&
-                    pos == i
+                if self[i].name != filterItem.name
+                    return true
+
+                return pos == i
 
     ###*
      * Generates the key used to store the parameters in the cache.

--- a/lib/ExtractMethodProvider/ParameterParser.coffee
+++ b/lib/ExtractMethodProvider/ParameterParser.coffee
@@ -26,6 +26,13 @@ class ParameterParser
     variableDeclarations: []
 
     ###*
+     * The selected range that we are scanning for parameters in.
+     *
+     * @type {Range}
+    ###
+    selectedBufferRange: null
+
+    ###*
      * Constructor
      *
      * @param {Parser} parser
@@ -44,6 +51,7 @@ class ParameterParser
      * @return {Array}
     ###
     findParameters: (editor, selectedBufferRange) ->
+        @selectedBufferRange = selectedBufferRange
         key = @buildKey(editor, selectedBufferRange)
 
         return @parsedParameters[key] if @parsedParameters[key]
@@ -269,7 +277,7 @@ class ParameterParser
         try
             type = @parser.getVariableType(
                 editor,
-                new Point(parameter.range.end.row + 1, parameter.range.end.column),
+                @selectedBufferRange.end,
                 parameter.name
             )
         catch error

--- a/lib/ExtractMethodProvider/ParameterParser.coffee
+++ b/lib/ExtractMethodProvider/ParameterParser.coffee
@@ -253,3 +253,11 @@ class ParameterParser
         parameter.type = type
 
         return parameter
+
+    ###*
+     * Returns all the variable declarations that have been parsed.
+     *
+     * @return {Array}
+    ###
+    getVariableDeclarations: ->
+        return @variableDeclarations

--- a/lib/ExtractMethodProvider/ParameterParser.coffee
+++ b/lib/ExtractMethodProvider/ParameterParser.coffee
@@ -1,0 +1,110 @@
+{Point, Range} = require 'atom'
+
+module.exports =
+
+class ParameterParser
+
+    findParameters: (editor, selectedBufferRange) ->
+        parameters = []
+
+        editor.scanInBufferRange /\$[a-zA-Z0-9_]+/g, selectedBufferRange, (element) =>
+            # Making sure we matched a variable and not a variable within a string
+            descriptions = editor.scopeDescriptorForBufferPosition(element.range.start)
+            indexOfDescriptor = descriptions.scopes.indexOf('variable.other.php')
+            if indexOfDescriptor > -1
+                parameters.push element.matchText
+
+        regexFilters = [
+            /as\s(\$[a-zA-Z0-9_]+)(?:\s=>\s(\$[a-zA-Z0-9_]+))?/g, # Foreach loops
+            /for\s*\(\s*(\$[a-zA-Z0-9_]+)\s*=/g, # For loops
+            /catch(?:.|\s)+(\$[a-zA-Z0-9_]+)/g, #Try/catch with line breaks
+            /function(?:\s|.)*?((?:\$[a-zA-Z0-9_]+)).*?\)/g, # Closure/Anonymous Function
+            /\s*?(\$[a-zA-Z0-9]+)\s*?=(?!>|=)/g # Variable declarations
+        ]
+
+        for filter in regexFilters
+            editor.scanInBufferRange filter, selectedBufferRange, (element) =>
+                variables = element.matchText.match /\$[a-zA-Z0-9]+/g
+                startPoint = new Point(element.range.end.row, 0)
+                scopeRange = @getRangeForCurrentScope editor, startPoint
+
+                scopeText = editor.getTextInBufferRange(scopeRange)
+                for variable in variables
+                    variableRegex = new RegExp("\\#{variable}", "g")
+                    variableOccurancesInCurrentScope = (scopeText.match(variableRegex) || []).length
+
+                    while true
+                        indexOfVariable = parameters.indexOf variable
+                        parameters.splice indexOfVariable, 1
+
+                        variableOccurancesInCurrentScope--
+                        break unless variableOccurancesInCurrentScope > 0
+
+
+        parameters = @makeUnique parameters
+
+        # Removing $this from parameters as this doesn't need to be passed in
+        if parameters.indexOf('$this') > -1
+            indexOfThis = parameters.indexOf('$this')
+            parameters.splice indexOfThis, 1
+
+        return parameters
+
+    getRangeForCurrentScope: (editor, bufferPosition) ->
+        startScopePoint = null
+        endScopePoint = null
+
+        # First walk back until we find the start of the current scope.
+        for row in [bufferPosition.row .. 0]
+            line = editor.lineTextForBufferRow(row)
+
+            continue if not line
+
+            lastIndex = line.length - 1
+
+            for i in [lastIndex .. 0]
+                descriptions = editor.scopeDescriptorForBufferPosition(
+                    [row, i]
+                )
+                indexOfDescriptor = descriptions.scopes.indexOf('punctuation.section.scope.begin.php')
+                if indexOfDescriptor > -1
+                    startScopePoint = new Point(row, 0)
+                    break
+
+            break if startScopePoint?
+
+        # Tracks any extra scopes that might exist inside the scope we are
+        # looking for.
+        childScopes = 0
+
+        # Walk forward until we find the end of the current scope
+        for row in [startScopePoint.row .. editor.getLineCount()]
+            line = editor.lineTextForBufferRow(row)
+
+            continue if not line
+
+            for i in [0 .. line.length - 1]
+                descriptions = editor.scopeDescriptorForBufferPosition(
+                    [row, i]
+                )
+
+                indexOfDescriptor = descriptions.scopes.indexOf('punctuation.section.scope.begin.php')
+                if indexOfDescriptor > -1
+                    childScopes++
+
+                indexOfDescriptor = descriptions.scopes.indexOf('punctuation.section.scope.end.php')
+                if indexOfDescriptor > -1
+                    if childScopes > 0
+                        childScopes--
+
+                    if childScopes == 0
+                        endScopePoint = new Point(row, i + 1)
+                        break
+
+            break if endScopePoint?
+
+        return new Range(startScopePoint, endScopePoint)
+
+    makeUnique: (array) =>
+        return array.filter (item, pos, self) ->
+            return self.indexOf(item) == pos;

--- a/lib/ExtractMethodProvider/ParameterParser.coffee
+++ b/lib/ExtractMethodProvider/ParameterParser.coffee
@@ -172,7 +172,12 @@ class ParameterParser
 
             continue if not line
 
-            for i in [0 .. line.length - 1]
+            startIndex = 0
+
+            if startScopePoint.row == row
+                startIndex = line.length - 1
+
+            for i in [startIndex .. line.length - 1]
                 descriptions = editor.scopeDescriptorForBufferPosition(
                     [row, i]
                 )

--- a/lib/ExtractMethodProvider/ParameterParser.coffee
+++ b/lib/ExtractMethodProvider/ParameterParser.coffee
@@ -206,10 +206,10 @@ class ParameterParser
         return array.filter (filterItem, pos, self) ->
             for i in [0 .. self.length - 1]
                 if self[i].name != filterItem.name
-                    return true
+                    continue
 
                 return pos == i
-
+            return true
     ###*
      * Generates the key used to store the parameters in the cache.
      *

--- a/lib/ExtractMethodProvider/View.coffee
+++ b/lib/ExtractMethodProvider/View.coffee
@@ -72,28 +72,34 @@ class ExtractMethodView extends View
                                         @option value: 'protected', 'Protected'
                                         @option value: 'private', 'Private'
                         @div class: 'control-group', =>
-                            @div class: 'controls', =>
-                                @div class: 'checkbox', =>
-                                    @label =>
-                                        @input outlet: 'generateDocInput', type: 'checkbox'
-                                        @div class: 'setting-title', 'Generate documentation'
-                            @div class: 'controls generate-docs-control hide', =>
-                                @div class: 'checkbox', =>
-                                    @label =>
-                                        @input outlet: 'generateDescPlaceholdersInput', type: 'checkbox', checked: true
-                                        @div class: 'setting-title', 'Generate description placeholders'
+                            @label class: 'control-label', =>
+                                @div class: 'setting-title', 'Documentation'
+                                @div class: 'controls', =>
+                                        @div class: 'checkbox', =>
+                                            @label =>
+                                                @input outlet: 'generateDocInput', type: 'checkbox'
+                                                @div class: 'setting-title', 'Generate documentation'
+                                @div class: 'controls generate-docs-control hide', =>
+                                    @div class: 'checkbox', =>
+                                        @label =>
+                                            @input outlet: 'generateDescPlaceholdersInput', type: 'checkbox', checked: true
+                                            @div class: 'setting-title', 'Generate description placeholders'
                         @div class: 'control-group', =>
-                            @div class: 'controls', =>
-                                @div class: 'checkbox', =>
-                                    @label =>
-                                        @input outlet: 'generateTypeHints', type: 'checkbox'
-                                        @div class: 'setting-title', 'Generate type hints'
+                            @label class: 'control-label', =>
+                                @div class: 'setting-title', 'Type hinting'
+                                @div class: 'controls', =>
+                                    @div class: 'checkbox', =>
+                                        @label =>
+                                            @input outlet: 'generateTypeHints', type: 'checkbox'
+                                            @div class: 'setting-title', 'Generate type hints'
                         @div class: 'return-multiple-control control-group hide', =>
-                            @div class: 'controls', =>
-                                @div class: 'checkbox', =>
-                                    @label =>
-                                        @input outlet: 'arraySyntax', type: 'checkbox', checked: true
-                                        @div class: 'setting-title', 'Use PHP 5.4+ array syntax (Square brackets)'
+                            @label class: 'control-label', =>
+                                @div class: 'setting-title', 'Method styling'
+                                @div class: 'controls', =>
+                                    @div class: 'checkbox', =>
+                                        @label =>
+                                            @input outlet: 'arraySyntax', type: 'checkbox', checked: true
+                                            @div class: 'setting-title', 'Use PHP 5.4+ array syntax (Square brackets)'
                         @div class: 'control-group', =>
                             @div class: 'controls', =>
                                 @label class: 'control-label', =>

--- a/lib/ExtractMethodProvider/View.coffee
+++ b/lib/ExtractMethodProvider/View.coffee
@@ -48,7 +48,7 @@ class ExtractMethodView extends View
             methodName: '',
             visibility: 'public',
             tabs: false,
-            arraySyntax: 'word'
+            arraySyntax: 'brackets'
         }
 
     ###*
@@ -79,7 +79,7 @@ class ExtractMethodView extends View
                             @div class: 'controls', =>
                                 @div class: 'checkbox', =>
                                     @label =>
-                                        @input outlet: 'arraySyntax', type: 'checkbox'
+                                        @input outlet: 'arraySyntax', type: 'checkbox', checked: true
                                         @div class: 'setting-title', 'Use PHP 5.4+ array syntax (Square brackets)'
                         @div class: 'control-group', =>
                             @div class: 'controls', =>

--- a/lib/ExtractMethodProvider/View.coffee
+++ b/lib/ExtractMethodProvider/View.coffee
@@ -49,7 +49,8 @@ class ExtractMethodView extends View
             visibility: 'public',
             tabs: false,
             arraySyntax: 'brackets',
-            typeHinting: false
+            typeHinting: false,
+            generateDocPlaceholders: true
         }
 
     ###*
@@ -76,6 +77,11 @@ class ExtractMethodView extends View
                                     @label =>
                                         @input outlet: 'generateDocInput', type: 'checkbox'
                                         @div class: 'setting-title', 'Generate documentation'
+                            @div class: 'controls generate-docs-control hide', =>
+                                @div class: 'checkbox', =>
+                                    @label =>
+                                        @input outlet: 'generateDocPlaceholdersInput', type: 'checkbox', checked: true
+                                        @div class: 'setting-title', 'Generate description placeholders'
                         @div class: 'control-group', =>
                             @div class: 'controls', =>
                                 @div class: 'checkbox', =>
@@ -126,6 +132,16 @@ class ExtractMethodView extends View
 
         $(@generateDocInput[0]).change (event) =>
             @settings.generateDocs = !@settings.generateDocs
+            if @settings.generateDocs == true
+                $('.php-integrator-refactoring-extract-method .generate-docs-control').removeClass('hide')
+            else
+                $('.php-integrator-refactoring-extract-method .generate-docs-control').addClass('hide')
+
+
+            @refreshPreviewArea()
+
+        $(@generateDocPlaceholdersInput[0]).change (event) =>
+            @settings.generateDocPlaceholders = !@settings.generateDocPlaceholders
             @refreshPreviewArea()
 
         $(@generateTypeHints[0]).change (event) =>

--- a/lib/ExtractMethodProvider/View.coffee
+++ b/lib/ExtractMethodProvider/View.coffee
@@ -48,7 +48,8 @@ class ExtractMethodView extends View
             methodName: '',
             visibility: 'public',
             tabs: false,
-            arraySyntax: 'brackets'
+            arraySyntax: 'brackets',
+            typeHinting: false
         }
 
     ###*
@@ -75,6 +76,12 @@ class ExtractMethodView extends View
                                     @label =>
                                         @input outlet: 'generateDocInput', type: 'checkbox'
                                         @div class: 'setting-title', 'Generate documentation'
+                        @div class: 'control-group', =>
+                            @div class: 'controls', =>
+                                @div class: 'checkbox', =>
+                                    @label =>
+                                        @input outlet: 'generateTypeHints', type: 'checkbox'
+                                        @div class: 'setting-title', 'Generate type hints'
                         @div class: 'return-multiple-control control-group hide', =>
                             @div class: 'controls', =>
                                 @div class: 'checkbox', =>
@@ -119,6 +126,10 @@ class ExtractMethodView extends View
 
         $(@generateDocInput[0]).change (event) =>
             @settings.generateDocs = !@settings.generateDocs
+            @refreshPreviewArea()
+
+        $(@generateTypeHints[0]).change (event) =>
+            @settings.typeHinting = !@settings.typeHinting
             @refreshPreviewArea()
 
         $(@arraySyntax[0]).change (event) =>

--- a/lib/ExtractMethodProvider/View.coffee
+++ b/lib/ExtractMethodProvider/View.coffee
@@ -125,7 +125,7 @@ class ExtractMethodView extends View
     present: ->
         @panel.show()
         @methodNameEditor.focus()
-        @refreshPreviewArea()
+        @methodNameEditor.setText('')
 
     ###*
      * Hides the panel.
@@ -133,7 +133,6 @@ class ExtractMethodView extends View
     hide: ->
         @panel.hide()
         @restoreFocus()
-        @methodNameEditor.setText('')
 
     ###*
      * Called when the user confirms the extraction and will then call

--- a/lib/ExtractMethodProvider/View.coffee
+++ b/lib/ExtractMethodProvider/View.coffee
@@ -176,6 +176,8 @@ class ExtractMethodView extends View
         if @builder.hasReturnValues()
             if @builder.hasMultipleReturnValues()
                 $('.php-integrator-refactoring-extract-method .return-multiple-control').removeClass('hide')
+            else
+                $('.php-integrator-refactoring-extract-method .return-multiple-control').addClass('hide')
 
             $('.php-integrator-refactoring-extract-method .return-control').removeClass('hide')
         else

--- a/lib/ExtractMethodProvider/View.coffee
+++ b/lib/ExtractMethodProvider/View.coffee
@@ -47,7 +47,8 @@ class ExtractMethodView extends View
             generateDocs: false,
             methodName: '',
             visibility: 'public',
-            tabs: false
+            tabs: false,
+            arraySyntax: 'word'
         }
 
     ###*
@@ -73,6 +74,12 @@ class ExtractMethodView extends View
                                     @label =>
                                         @input outlet: 'generateDocInput', type: 'checkbox'
                                         @div class: 'setting-title', 'Generate documentation'
+                        @div class: 'return-multiple-control control-group hide', =>
+                            @div class: 'controls', =>
+                                @div class: 'checkbox', =>
+                                    @label =>
+                                        @input outlet: 'arraySyntax', type: 'checkbox'
+                                        @div class: 'setting-title', 'Use PHP 5.4+ array syntax (Square brackets)'
                         @div class: 'control-group', =>
                             @div class: 'controls', =>
                                 @label class: 'control-label', =>
@@ -108,6 +115,13 @@ class ExtractMethodView extends View
 
         $(@generateDocInput[0]).change (event) =>
             @settings.generateDocs = !@settings.generateDocs
+            @refreshPreviewArea()
+
+        $(@arraySyntax[0]).change (event) =>
+            if @settings.arraySyntax == 'word'
+                @settings.arraySyntax = 'brackets'
+            else
+                @settings.arraySyntax = 'word'
             @refreshPreviewArea()
 
         @panel ?= atom.workspace.addModalPanel(item: this, visible: false)
@@ -159,6 +173,15 @@ class ExtractMethodView extends View
     ###
     refreshPreviewArea: ->
         methodBody = @builder.buildMethod(@getSettings())
+        if @builder.hasReturnValues()
+            if @builder.hasMultipleReturnValues()
+                $('.php-integrator-refactoring-extract-method .return-multiple-control').removeClass('hide')
+
+            $('.php-integrator-refactoring-extract-method .return-control').removeClass('hide')
+        else
+            $('.php-integrator-refactoring-extract-method .return-control').addClass('hide')
+            $('.php-integrator-refactoring-extract-method .return-multiple-control').addClass('hide')
+
         $(@previewArea).text(methodBody)
 
     ###*

--- a/lib/ExtractMethodProvider/View.coffee
+++ b/lib/ExtractMethodProvider/View.coffee
@@ -50,7 +50,7 @@ class ExtractMethodView extends View
             tabs: false,
             arraySyntax: 'brackets',
             typeHinting: false,
-            generateDocPlaceholders: true
+            generateDescPlaceholders: true
         }
 
     ###*
@@ -80,7 +80,7 @@ class ExtractMethodView extends View
                             @div class: 'controls generate-docs-control hide', =>
                                 @div class: 'checkbox', =>
                                     @label =>
-                                        @input outlet: 'generateDocPlaceholdersInput', type: 'checkbox', checked: true
+                                        @input outlet: 'generateDescPlaceholdersInput', type: 'checkbox', checked: true
                                         @div class: 'setting-title', 'Generate description placeholders'
                         @div class: 'control-group', =>
                             @div class: 'controls', =>
@@ -140,8 +140,8 @@ class ExtractMethodView extends View
 
             @refreshPreviewArea()
 
-        $(@generateDocPlaceholdersInput[0]).change (event) =>
-            @settings.generateDocPlaceholders = !@settings.generateDocPlaceholders
+        $(@generateDescPlaceholdersInput[0]).change (event) =>
+            @settings.generateDescPlaceholders = !@settings.generateDescPlaceholders
             @refreshPreviewArea()
 
         $(@generateTypeHints[0]).change (event) =>

--- a/lib/ExtractMethodProvider/View.coffee
+++ b/lib/ExtractMethodProvider/View.coffee
@@ -172,6 +172,8 @@ class ExtractMethodView extends View
      * Updates the preview area using the current setttings.
     ###
     refreshPreviewArea: ->
+        return unless @panel.isVisible()
+
         methodBody = @builder.buildMethod(@getSettings())
         if @builder.hasReturnValues()
             if @builder.hasMultipleReturnValues()

--- a/lib/ExtractMethodProvider/View.coffee
+++ b/lib/ExtractMethodProvider/View.coffee
@@ -146,7 +146,7 @@ class ExtractMethodView extends View
 
 
         $(document).on 'click', (event) =>
-            @cancel() if @panel.isVisible()
+            @cancel() if @panel?.isVisible()
 
     ###*
      * Destroys the view and cleans up.
@@ -167,7 +167,7 @@ class ExtractMethodView extends View
      * Hides the panel.
     ###
     hide: ->
-        @panel.hide()
+        @panel?.hide()
         @restoreFocus()
 
     ###*

--- a/lib/ExtractMethodProvider/View.coffee
+++ b/lib/ExtractMethodProvider/View.coffee
@@ -1,0 +1,149 @@
+{$, TextEditorView, View} = require 'atom-space-pen-views'
+
+Parser = require('./Builder')
+
+module.exports =
+
+class ExtractMethodView extends View
+
+    ###*
+     * The callback to invoke when the user confirms his selections.
+    ###
+    onDidConfirm  : null
+
+    ###*
+     * The callback to invoke when the user cancels the view.
+    ###
+    onDidCancel   : null
+
+    ###*
+     * Settings of how to generate new method that will be passed to the parser
+    ###
+    settings      : null
+
+    ###*
+     * Builder to use when generating preview area
+    ###
+    builder       : null
+
+    ###*
+     * Constructor.
+     *
+     * @param {Callback} onDidConfirm
+     * @param {Callback} onDidCancel
+    ###
+    constructor: (@onDidConfirm, @onDidCancel = null) ->
+        super()
+
+        @settings = {
+            generateDocs: false,
+            methodName: '',
+            visibility: 'public',
+            tabs: false
+        }
+
+    @content: ->
+        @div class: 'php-integrator-refactoring-extract-method', =>
+            @div outlet: 'methodNameForm', =>
+                @subview 'methodNameEditor', new TextEditorView(mini:true, placeholderText: 'Enter a method name')
+                @div class: 'settings-view', =>
+                    @div class: 'section-body', =>
+                        @div class: 'control-group', =>
+                            @div class: 'controls', =>
+                                @label class: 'control-label', =>
+                                    @div class: 'setting-title', 'Access Modifier'
+                                    @select outlet: 'accessMethodsInput', class: 'form-control', =>
+                                        @option value: 'public', 'Public'
+                                        @option value: 'protected', 'Protected'
+                                        @option value: 'private', 'Private'
+                        @div class: 'control-group', =>
+                            @div class: 'controls', =>
+                                @div class: 'checkbox', =>
+                                    @label =>
+                                        @input outlet: 'generateDocInput', type: 'checkbox'
+                                        @div class: 'setting-title', 'Generate documentation'
+                        @div class: 'control-group', =>
+                            @div class: 'controls', =>
+                                @label class: 'control-label', =>
+                                    @div class: 'setting-title', 'Preview'
+                                    @pre class: 'preview-area', outlet: 'previewArea'
+            @div outlet: 'buttonGroup', class: 'block pull-right', =>
+                @button class: 'inline-block btn btn-success button--confirm', 'Extract method'
+                @button class: 'inline-block btn button--cancel', 'Cancel'
+
+    initialize: ->
+        atom.commands.add @element,
+            'core:confirm': (event) =>
+                @confirm()
+                event.stopPropagation()
+            'core:cancel': (event) =>
+                @cancel()
+                event.stopPropagation()
+
+        @on 'click', 'button', (event) =>
+            @confirm()  if $(event.target).hasClass('button--confirm')
+            @cancel()   if $(event.target).hasClass('button--cancel')
+
+        @methodNameEditor.getModel().onDidChange () =>
+            @settings.methodName = @methodNameEditor.getText()
+            @refreshPreviewArea()
+
+        $(@accessMethodsInput[0]).change (event) =>
+            @settings.visibility = $(event.target).val()
+            @refreshPreviewArea()
+
+        $(@generateDocInput[0]).change (event) =>
+            @settings.generateDocs = !@settings.generateDocs
+            @refreshPreviewArea()
+
+        @panel ?= atom.workspace.addModalPanel(item: this, visible: false)
+
+    ###*
+     * Destroys the view and cleans up.
+    ###
+    destroy: ->
+        @panel.destroy()
+        @panel = null
+
+    present: ->
+        @panel.show()
+        @methodNameEditor.focus()
+        @refreshPreviewArea()
+
+    hide: ->
+        @panel.hide()
+        @restoreFocus()
+        @methodNameEditor.setText('')
+
+    confirm: ->
+        if @onDidConfirm
+            @onDidConfirm(@getSettings())
+
+        @hide()
+
+    cancel: ->
+        if @onDidCancel
+            @onDidCancel()
+
+        @hide()
+
+    refreshPreviewArea: ->
+        methodBody = @builder.buildMethod(@getSettings())
+        $(@previewArea).text(methodBody)
+
+    storeFocusedElement: ->
+        @previouslyFocusedElement = $(document.activeElement)
+
+    restoreFocus: ->
+        @previouslyFocusedElement?.focus()
+
+    setBuilder: (builder) ->
+        @builder = builder
+
+    ###*
+     * Gets the settings currently set
+     *
+     * @return {Object}
+    ###
+    getSettings: ->
+        return @settings

--- a/lib/ExtractMethodProvider/View.coffee
+++ b/lib/ExtractMethodProvider/View.coffee
@@ -8,21 +8,29 @@ class ExtractMethodView extends View
 
     ###*
      * The callback to invoke when the user confirms his selections.
+     *
+     * @type {Callback}
     ###
     onDidConfirm  : null
 
     ###*
      * The callback to invoke when the user cancels the view.
+     *
+     * @type {Callback}
     ###
     onDidCancel   : null
 
     ###*
      * Settings of how to generate new method that will be passed to the parser
+     *
+     * @type {Object}
     ###
     settings      : null
 
     ###*
      * Builder to use when generating preview area
+     *
+     * @type {Builder}
     ###
     builder       : null
 
@@ -42,6 +50,9 @@ class ExtractMethodView extends View
             tabs: false
         }
 
+    ###*
+     * Content to be displayed when this view is shown.
+    ###
     @content: ->
         @div class: 'php-integrator-refactoring-extract-method', =>
             @div outlet: 'methodNameForm', =>
@@ -71,6 +82,9 @@ class ExtractMethodView extends View
                 @button class: 'inline-block btn btn-success button--confirm', 'Extract method'
                 @button class: 'inline-block btn button--cancel', 'Cancel'
 
+    ###*
+     * @inheritdoc
+    ###
     initialize: ->
         atom.commands.add @element,
             'core:confirm': (event) =>
@@ -105,38 +119,68 @@ class ExtractMethodView extends View
         @panel.destroy()
         @panel = null
 
+    ###*
+    * Shows the view and refreshes the preview area with the current settings.
+    ###
     present: ->
         @panel.show()
         @methodNameEditor.focus()
         @refreshPreviewArea()
 
+    ###*
+     * Hides the panel.
+    ###
     hide: ->
         @panel.hide()
         @restoreFocus()
         @methodNameEditor.setText('')
 
+    ###*
+     * Called when the user confirms the extraction and will then call
+     * onDidConfirm, if set.
+    ###
     confirm: ->
         if @onDidConfirm
             @onDidConfirm(@getSettings())
 
         @hide()
 
+    ###*
+     * Called when the user cancels the extraction and will then call
+     * onDidCancel, if set.
+    ###
     cancel: ->
         if @onDidCancel
             @onDidCancel()
 
         @hide()
 
+    ###*
+     * Updates the preview area using the current setttings.
+    ###
     refreshPreviewArea: ->
         methodBody = @builder.buildMethod(@getSettings())
         $(@previewArea).text(methodBody)
 
+    ###*
+     * Stores the currently focused element so it can be returned focus after
+     * this panel is hidden.
+    ###
     storeFocusedElement: ->
         @previouslyFocusedElement = $(document.activeElement)
 
+    ###*
+     * Restores focus back to the element that was focused before this panel
+     * was shown.
+    ###
     restoreFocus: ->
         @previouslyFocusedElement?.focus()
 
+    ###*
+     * Sets the builder to use when generating the preview area.
+     *
+     * @param {Builder} builder
+    ###
     setBuilder: (builder) ->
         @builder = builder
 

--- a/lib/ExtractMethodProvider/View.coffee
+++ b/lib/ExtractMethodProvider/View.coffee
@@ -85,9 +85,10 @@ class ExtractMethodView extends View
                                 @label class: 'control-label', =>
                                     @div class: 'setting-title', 'Preview'
                                     @pre class: 'preview-area', outlet: 'previewArea'
-            @div outlet: 'buttonGroup', class: 'block pull-right', =>
-                @button class: 'inline-block btn btn-success button--confirm', 'Extract method'
-                @button class: 'inline-block btn button--cancel', 'Cancel'
+            @div class: 'button-bar', =>
+                @button class: 'btn btn-error inline-block-tight pull-left icon icon-circle-slash button--cancel', 'Cancel'
+                @button class: 'btn btn-success inline-block-tight pull-right icon icon-gear button--confirm', 'Extract'
+
 
     ###*
      * @inheritdoc

--- a/lib/ExtractMethodProvider/View.coffee
+++ b/lib/ExtractMethodProvider/View.coffee
@@ -126,6 +126,13 @@ class ExtractMethodView extends View
 
         @panel ?= atom.workspace.addModalPanel(item: this, visible: false)
 
+        @on 'click', document, (event) =>
+            event.stopPropagation()
+
+
+        $(document).on 'click', (event) =>
+            @cancel() if @panel.isVisible()
+
     ###*
      * Destroys the view and cleans up.
     ###

--- a/lib/ExtractMethodProvider/View.coffee
+++ b/lib/ExtractMethodProvider/View.coffee
@@ -58,6 +58,7 @@ class ExtractMethodView extends View
         @div class: 'php-integrator-refactoring-extract-method', =>
             @div outlet: 'methodNameForm', =>
                 @subview 'methodNameEditor', new TextEditorView(mini:true, placeholderText: 'Enter a method name')
+                @div class: 'text-error error-message hide error-message--method-name', 'You must enter a method name!'
                 @div class: 'settings-view', =>
                     @div class: 'section-body', =>
                         @div class: 'control-group', =>
@@ -108,6 +109,8 @@ class ExtractMethodView extends View
 
         @methodNameEditor.getModel().onDidChange () =>
             @settings.methodName = @methodNameEditor.getText()
+            $('.php-integrator-refactoring-extract-method .error-message--method-name').addClass('hide');
+
             @refreshPreviewArea()
 
         $(@accessMethodsInput[0]).change (event) =>
@@ -161,6 +164,10 @@ class ExtractMethodView extends View
      * onDidConfirm, if set.
     ###
     confirm: ->
+        if @settings.methodName == ''
+            $('.php-integrator-refactoring-extract-method .error-message--method-name').removeClass('hide');
+            return false
+
         if @onDidConfirm
             @onDidConfirm(@getSettings())
 

--- a/lib/Main.coffee
+++ b/lib/Main.coffee
@@ -20,9 +20,11 @@ module.exports =
     ###
     activateProviders: (service) ->
         GetterSetterProvider = require './GetterSetterProvider'
+        ExtractMethodProvider = require './ExtractMethodProvider'
 
         @providers = []
         @providers.push new GetterSetterProvider()
+        @providers.push new ExtractMethodProvider()
 
         for provider in @providers
             provider.activate(service)

--- a/lib/Main.coffee
+++ b/lib/Main.coffee
@@ -49,3 +49,12 @@ module.exports =
         {Disposable} = require 'atom'
 
         return new Disposable => @deactivateProviders()
+
+    ###*
+     * Consumes the atom/snippet service
+     *
+     * @param {Object} snippetManager
+    ###
+    setSnippetManager: (snippetManager) ->
+        for provider in @providers
+            provider.setSnippetManager snippetManager

--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
       "versions": {
         "~0.6.0": "setService"
       }
+    },
+    "snippets": {
+      "versions": {
+        "0.1.0": "setSnippetManager"
+      }
     }
   },
   "dependencies": {

--- a/styles/main.less
+++ b/styles/main.less
@@ -26,3 +26,21 @@
         // margin-top: 0.5em;
     }
 }
+
+.php-integrator-refactoring-extract-method {
+    .section-body, .form-control, .control-label, .control-group, .controls {
+        width: 100%;
+    }
+    .preview-area {
+        max-height: 400px;
+    }
+    // Should change to reflect the padding of the theme instead of hardcoded.
+    .block {
+        margin-top: 4px;
+    }
+    .pull-right {
+        .inline-block {
+            margin-left: 9px;
+        }
+    }
+}

--- a/styles/main.less
+++ b/styles/main.less
@@ -43,4 +43,14 @@
             margin-left: 9px;
         }
     }
+
+    .checkbox {
+        // Removing any extra margining to the checkboxes (e.g. Atom Material)
+        margin-top: 5px;
+        margin-bottom: 5px;
+    }
+
+    .settings-view .section-body {
+        margin-top: 0px;
+    }
 }


### PR DESCRIPTION
Hi,

I originally made a package called `php-extract-method`, it allows users to select a piece of code and extract it out into another function (idea taken from PHPStorm). This was alright and had basic functionality but there were a few bugs and sometimes the spacing was off. What I've done is take some of that and move it into this package. But I've made many improvements when doing this and completely rewrote the logic for getting the parameters needed. 

Planning to deprecate my old package if you are happy with this, as this version is much better.
##### Improvements
1. It now tries to guess the variables you want to return from the method and adds them to the end of the new method. (It also handles multiple returns by using `list` function in php
2. Using all your hard work with the php-integrator-base I'm now able to guess the types of the parameters being passed and the return variable. Then use those types on the docblock.
3. Overall improved the consistency when parsing the parameters to set.
4. General performance improvements.

There's still a small feature that I want to add, which is to allow users to set whether they want to pass the parameters in by reference or for it to return the variables like it currently does. But this feature isn't too important so it can be done at a later date.

I'm adding this feature to this package because it seemed to make more sense to me, rather than creating my own package.

Hope this helps and makes sense. If you have any questions please don't hesitate to ask me.

Thanks
Chris
